### PR TITLE
Add support for local storage

### DIFF
--- a/sdk/go/abc-updater/localstore/local_store_test.go
+++ b/sdk/go/abc-updater/localstore/local_store_test.go
@@ -41,9 +41,9 @@ func TestInitWithDir(t *testing.T) {
 			want: &localStore{directory: filepath.Join(tempDir, "hello_1")},
 		},
 		{
-			name:    "empty_dir",
+			name:    "empty_string_dir",
 			dir:     "",
-			wantErr: "must supply non empty directory",
+			wantErr: "directory cannot be empty string",
 		},
 	}
 


### PR DESCRIPTION
The purpose of this is to be able to save state to the users machine so we can only check for updates every so often (e.g., once a day).

Defaults to save to ~/.config/abcupdater/$APP_NAME which can be overridden.
Saves data as JSON.

Start out here with 3 basic functions.

initLocalStore - will create directories if necessary
loadLocalData - loads the local data (currently just last version check timestamp)
updateLocalData - updates local data with the object provided

In the future this can be expanded to save other things such as persistent configs or other state data.