### PR TITLE
Fix draft-release bootstrapping

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -74,7 +74,8 @@ jobs:
             owner: context.repo.owner,
             repo: context.repo.repo,
             tag_name: `v${process.env.NEXT_VERSION}`,
-            previous_tag_name: `v${process.env.CURRENT_VERSION}`,
+            // Bootstrapping problem for first release, as 0.0.0 tag doesn't exist.
+            previous_tag_name: process.env.CURRENT_VERSION != '0.0.0' ? `v${process.env.CURRENT_VERSION}` : null,
           });
           core.setOutput('release-notes', releaseNotesResponse.data.body)
 


### PR DESCRIPTION
If first release, should not have previous tag in request.