### PR TITLE
Add concurrency helper function built into abc-updater.

### DIFF
--- a/pkg/abcupdater/version.go
+++ b/pkg/abcupdater/version.go
@@ -105,7 +105,7 @@ To disable notifications for this new version, set {{.OptOutEnvVar}}="{{.Current
 func CheckAppVersion(ctx context.Context, params *CheckVersionParams, out func(string)) (func(), error) {
 	cancel := func() {}
 	if _, ok := ctx.Deadline(); !ok {
-		ctx, cancel = context.WithTimeout(ctx, time.Second*2) //nolint:lostcancel
+		ctx, cancel = context.WithTimeout(ctx, time.Second*2) //nolint:govet
 	}
 
 	lookuper := params.Lookuper
@@ -118,7 +118,7 @@ func CheckAppVersion(ctx context.Context, params *CheckVersionParams, out func(s
 		Lookuper: lookuper,
 	}); err != nil {
 		// This leaks context. OK since only runs once, and timeout is short.
-		return nil, fmt.Errorf("failed to process envconfig: %w", err) //nolint:lostcancel
+		return nil, fmt.Errorf("failed to process envconfig: %w", err) //nolint:govet
 	}
 	return asyncFunctionCall(ctx, func() (string, error) {
 		defer cancel()

--- a/pkg/abcupdater/version.go
+++ b/pkg/abcupdater/version.go
@@ -136,7 +136,7 @@ func CheckAppVersionSync(ctx context.Context, params *CheckVersionParams) (strin
 
 	optOutSettings, err := loadOptOutSettings(ctx, lookuper, params.AppID)
 	if err != nil {
-		return "", fmt.Errorf("failed to load opt out setings: %w", err)
+		return "", fmt.Errorf("failed to load opt out settings: %w", err)
 	}
 
 	if optOutSettings.allVersionUpdatesIgnored() {

--- a/pkg/abcupdater/version.go
+++ b/pkg/abcupdater/version.go
@@ -96,7 +96,7 @@ To disable notifications for this new version, set {{.OptOutEnvVar}}="{{.Current
 // to be run after program logic which will block until a response is returned
 // or a timeout is hit. If there is any output, out() will be run during the
 // returned closure, for the consumer to print to user.
-// Example out(): `func(s string) {fmt.Fprintf(os.Stderr, "%s\n", s)}`
+// Example out(): `func(s string) {fmt.Fprintf(os.Stderr, "%s\n", s)}.`
 func CheckAppVersion(ctx context.Context, params *CheckVersionParams, out func(string)) (func(), error) {
 	lookuper := params.Lookuper
 	if lookuper == nil {

--- a/pkg/abcupdater/version.go
+++ b/pkg/abcupdater/version.go
@@ -27,11 +27,11 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/abcxyz/pkg/logging"
 	"github.com/hashicorp/go-version"
 	"github.com/sethvargo/go-envconfig"
 
 	"github.com/abcxyz/abc-updater/pkg/abcupdater/localstore"
+	"github.com/abcxyz/pkg/logging"
 )
 
 // CheckVersionParams are the parameters for checking for application updates.

--- a/pkg/abcupdater/version.go
+++ b/pkg/abcupdater/version.go
@@ -105,7 +105,7 @@ To disable notifications for this new version, set {{.OptOutEnvVar}}="{{.Current
 func CheckAppVersion(ctx context.Context, params *CheckVersionParams, out func(string)) (func(), error) {
 	cancel := func() {}
 	if _, ok := ctx.Deadline(); !ok {
-		ctx, cancel = context.WithTimeout(ctx, time.Second*2)
+		ctx, cancel = context.WithTimeout(ctx, time.Second*2) //nolint:lostcancel
 	}
 
 	lookuper := params.Lookuper
@@ -118,7 +118,7 @@ func CheckAppVersion(ctx context.Context, params *CheckVersionParams, out func(s
 		Lookuper: lookuper,
 	}); err != nil {
 		// This leaks context. OK since only runs once, and timeout is short.
-		return nil, fmt.Errorf("failed to process envconfig: %w", err)
+		return nil, fmt.Errorf("failed to process envconfig: %w", err) //nolint:lostcancel
 	}
 	return asyncFunctionCall(ctx, func() (string, error) {
 		defer cancel()

--- a/pkg/abcupdater/version.go
+++ b/pkg/abcupdater/version.go
@@ -105,7 +105,7 @@ To disable notifications for this new version, set {{.OptOutEnvVar}}="{{.Current
 func CheckAppVersion(ctx context.Context, params *CheckVersionParams, out func(string)) (func(), error) {
 	cancel := func() {}
 	if _, ok := ctx.Deadline(); !ok {
-		ctx, cancel = context.WithTimeout(ctx, time.Second*2) //nolint:govet
+		ctx, cancel = context.WithTimeout(ctx, time.Second*2)
 	}
 
 	lookuper := params.Lookuper
@@ -117,8 +117,8 @@ func CheckAppVersion(ctx context.Context, params *CheckVersionParams, out func(s
 		Target:   &c,
 		Lookuper: lookuper,
 	}); err != nil {
-		// This leaks context. OK since only runs once, and timeout is short.
-		return nil, fmt.Errorf("failed to process envconfig: %w", err) //nolint:govet
+		cancel()
+		return nil, fmt.Errorf("failed to process envconfig: %w", err)
 	}
 	return asyncFunctionCall(ctx, func() (string, error) {
 		defer cancel()

--- a/pkg/abcupdater/version.go
+++ b/pkg/abcupdater/version.go
@@ -60,7 +60,7 @@ type AppResponse struct {
 }
 
 type config struct {
-	ServerURL      string        `env:"ABC_UPDATER_URL,default=https://abc-updater.tycho.joonix.net"`
+	ServerURL string `env:"ABC_UPDATER_URL,default=https://abc-updater.tycho.joonix.net"`
 }
 
 // LocalVersionData defines the json file that caches version lookup data.
@@ -96,16 +96,16 @@ To disable notifications for this new version, set {{.OptOutEnvVar}}="{{.Current
 // or provided context is canceled. If no provided deadline in context, defaults to 2 seconds.
 // If there is an update, out() will be called during the
 // returned closure.
+// TODO: fill out docs
 // If no update is available:
 // If there is an error:
 // If the context is canceled: out() is not called in the case of context cancellation.
 // Example out(): `func(s string) {fmt.Fprintln(os.Stderr, s)}`.
 func CheckAppVersion(ctx context.Context, params *CheckVersionParams, out func(string)) (func(), error) {
-	cancel := func(){}
+	cancel := func() {}
 	if _, ok := ctx.Deadline(); !ok {
-		ctx, cancel = context.WithTimeout(ctx, time.seconds * 2)
+		ctx, cancel = context.WithTimeout(ctx, time.Second*2)
 	}
-
 
 	lookuper := params.Lookuper
 	if lookuper == nil {
@@ -170,9 +170,7 @@ func CheckAppVersionSync(ctx context.Context, params *CheckVersionParams) (strin
 		return "", fmt.Errorf("failed to parse check version %q: %w", params.Version, err)
 	}
 
-	// client := &http.Client{
-	// 	Timeout: c.RequestTimeout,
-	// }
+	client := &http.Client{}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf(appDataURLFormat, c.ServerURL, params.AppID), nil)
 	if err != nil {

--- a/pkg/abcupdater/version.go
+++ b/pkg/abcupdater/version.go
@@ -117,6 +117,7 @@ func CheckAppVersion(ctx context.Context, params *CheckVersionParams, out func(s
 		Target:   &c,
 		Lookuper: lookuper,
 	}); err != nil {
+		// This leaks context. OK since only runs once, and timeout is short.
 		return nil, fmt.Errorf("failed to process envconfig: %w", err)
 	}
 	return asyncFunctionCall(ctx, func() (string, error) {

--- a/pkg/abcupdater/version.go
+++ b/pkg/abcupdater/version.go
@@ -96,7 +96,7 @@ To disable notifications for this new version, set {{.OptOutEnvVar}}="{{.Current
 // to be run after program logic which will block until a response is returned
 // or a timeout is hit. If there is any output, out() will be run during the
 // returned closure, for the consumer to print to user.
-// Example out(): `func(s string) {fmt.Fprintf(os.Stderr, "%s\n", s)}.`
+// Example out(): `func(s string) {fmt.Fprintf(os.Stderr, "%s\n", s)}`.
 func CheckAppVersion(ctx context.Context, params *CheckVersionParams, out func(string)) (func(), error) {
 	lookuper := params.Lookuper
 	if lookuper == nil {

--- a/pkg/abcupdater/version.go
+++ b/pkg/abcupdater/version.go
@@ -96,10 +96,11 @@ To disable notifications for this new version, set {{.OptOutEnvVar}}="{{.Current
 // or provided context is canceled. If no provided deadline in context, defaults to 2 seconds.
 // If there is an update, out() will be called during the
 // returned closure.
-// TODO: fill out docs
-// If no update is available:
-// If there is an error:
-// If the context is canceled: out() is not called in the case of context cancellation.
+//
+// If no update is available: out() will not be called.
+// If there is an error: out() will not be called, message will be logged as WARN.
+// If the context is canceled: out() is not called.
+// If processing config fails: an error will be returned synchronously.
 // Example out(): `func(s string) {fmt.Fprintln(os.Stderr, s)}`.
 func CheckAppVersion(ctx context.Context, params *CheckVersionParams, out func(string)) (func(), error) {
 	cancel := func() {}

--- a/pkg/abcupdater/version_test.go
+++ b/pkg/abcupdater/version_test.go
@@ -236,6 +236,7 @@ func Test_asyncFunctionCall(t *testing.T) {
 		// how to make it not leak into rest of test cases
 	}
 	for _, tc := range cases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			outBuf := bytes.Buffer{}

--- a/pkg/abcupdater/version_test.go
+++ b/pkg/abcupdater/version_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/abcxyz/pkg/testutil"
 )
 
-// Instrumented io.Writer
+// Instrumented io.Writer.
 type testWriter struct {
 	Buf    bytes.Buffer
 	Writes int64

--- a/pkg/abcupdater/version_test.go
+++ b/pkg/abcupdater/version_test.go
@@ -15,7 +15,6 @@
 package abcupdater
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -183,11 +182,9 @@ To disable notifications for this new version, set SAMPLE_APP_1_IGNORE_VERSIONS=
 
 			cacheFile := filepath.Join(t.TempDir(), "data.json")
 
-			var b bytes.Buffer
 			params := &CheckVersionParams{
 				AppID:             tc.appID,
 				Version:           tc.version,
-				Writer:            &b,
 				Lookuper:          envconfig.MapLookuper(tc.env),
 				CacheFileOverride: cacheFile,
 			}
@@ -198,12 +195,12 @@ To disable notifications for this new version, set SAMPLE_APP_1_IGNORE_VERSIONS=
 				}
 			}
 
-			err := CheckAppVersion(context.Background(), params)
+			output, err := CheckAppVersion(context.Background(), params)
 			if diff := testutil.DiffErrString(err, tc.wantErr); diff != "" {
 				t.Error(diff)
 			}
 
-			if got, want := b.String(), tc.want; got != want {
+			if got, want := output, tc.want; got != want {
 				t.Errorf("incorrect output got=%s, want=%s", got, want)
 			}
 		})

--- a/pkg/abcupdater/version_test.go
+++ b/pkg/abcupdater/version_test.go
@@ -202,7 +202,7 @@ To disable notifications for this new version, set SAMPLE_APP_1_IGNORE_VERSIONS=
 			}
 
 			if tc.cached != nil {
-				if err := params.setLocalCachedData(tc.cached); err != nil {
+				if err := setLocalCachedData(params, tc.cached); err != nil {
 					t.Errorf("unexpected error setting up test cache file: %v", err)
 				}
 			}

--- a/pkg/abcupdater/version_test.go
+++ b/pkg/abcupdater/version_test.go
@@ -219,7 +219,7 @@ func Test_asyncFunctionCall(t *testing.T) {
 		{
 			name:  "happy_path",
 			input: func() (string, error) { return "done", nil },
-			want:  "done",
+			want:  "done\n",
 		},
 		{
 			name:  "error_path_still_returns",


### PR DESCRIPTION
Based on @drevell 's suggestion https://github.com/abcxyz/abc/pull/415#discussion_r1542065771

An async version of the helper is provided, so consumers do not need to worry about properly implementing currency.

Remove http timeout, instead relying on caller-provided (or if none, generated) context for timeout.