### PR TITLE
Simplify update message to be a single line.

### DIFF
--- a/pkg/abcupdater/version_test.go
+++ b/pkg/abcupdater/version_test.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/google/go-cmp/cmp"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -27,6 +26,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/sethvargo/go-envconfig"
 
 	"github.com/abcxyz/pkg/testutil"


### PR DESCRIPTION
Remove trailing newline on update message, allowing consumer to choose how to format.