### PR TITLE
Route metrics logs to dedicated cloud logging bucket

### DIFF
--- a/terraform/cloudrun.tf
+++ b/terraform/cloudrun.tf
@@ -63,9 +63,7 @@ resource "google_cloud_run_v2_service_iam_member" "public_metrics_access" {
   location = google_cloud_run_v2_service.metrics.location
   name     = google_cloud_run_v2_service.metrics.name
   role     = "roles/run.invoker"
-  members = [
-    "allUsers"
-  ]
+  member   = "allUsers"
 }
 
 // We want more narrow permissions than the default cloud run service account.

--- a/terraform/cloudrun.tf
+++ b/terraform/cloudrun.tf
@@ -57,7 +57,7 @@ resource "google_cloud_run_v2_service" "metrics" {
   }
 }
 
-resource "google_cloud_run_v2_service_iam_binding" "public_metrics_access" {
+resource "google_cloud_run_v2_service_iam_member" "public_metrics_access" {
   project = var.project_id
 
   location = google_cloud_run_v2_service.metrics.location

--- a/terraform/cloudrun.tf
+++ b/terraform/cloudrun.tf
@@ -57,6 +57,17 @@ resource "google_cloud_run_v2_service" "metrics" {
   }
 }
 
+resource "google_cloud_run_v2_service_iam_binding" "public_metrics_access" {
+  project = var.project_id
+
+  location = google_cloud_run_v2_service.metrics.location
+  name     = google_cloud_run_v2_service.metrics.name
+  role     = "roles/run.invoker"
+  members = [
+    "allUsers"
+  ]
+}
+
 // We want more narrow permissions than the default cloud run service account.
 resource "google_service_account" "cloud_run_service_account" {
   project = var.project_id

--- a/terraform/logging.tf
+++ b/terraform/logging.tf
@@ -1,0 +1,36 @@
+# Copyright 2024 The Authors (see AUTHORS file)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resource "google_logging_project_bucket_config" "metrics" {
+  project = var.project_id
+
+  location         = var.compute_region
+  retention_days   = var.metrics_log_bucket_retention_days
+  bucket_id        = var.metrics_log_bucket_name
+  enable_analytics = true
+}
+
+resource "google_logging_project_sink" "metrics" {
+  project = var.project_id
+
+  name                   = "abc-updater-metrics-sink"
+  destination            = "logging.googleapis.com/${google_logging_project_bucket_config.metrics.name}"
+  unique_writer_identity = true
+  filter = <<EOF
+  resource.type="cloud_run_revision" AND
+  resource.labels.service_name="${var.metrics_service_name}" AND
+  jsonPayload.message="metric received"
+  EOF
+
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -18,7 +18,7 @@ variable "project_id" {
 }
 
 variable "bucket_name" {
-  description = "The name of the GCS bucket."
+  description = "The name of the GCS bucket holding update and metrics definitions."
   type        = string
 }
 
@@ -30,6 +30,17 @@ variable "bucket_object_admins" {
 variable "metrics_service_name" {
   description = "Name for Cloud Run service for metrics server."
   type        = string
+}
+
+variable "metrics_log_bucket_name" {
+  description = "Name for Log Bucket metrics server logs are sent to. Must be unique."
+  type        = string
+}
+
+variable "metrics_log_bucket_retention_days" {
+  description = "Number of days to keep metrics logs."
+  type        = number
+  default     = 30
 }
 
 variable "compute_region" {


### PR DESCRIPTION
This bucket will only have logs containing the raw metrics, and is enabled for analytics for easy querying.