### PR TITLE
Add storing metrics client in context

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -35,7 +35,7 @@ const (
 	installIDFileName     = "id.json"
 	maxErrorResponseBytes = 2048
 
-	// metricsKey points to the value in the context where the logger is stored.
+	// metricsKey points to the value in the context where the client is stored.
 	metricsKey = contextKey("metricsClient")
 )
 
@@ -267,7 +267,7 @@ func NoopWriter() MetricWriter {
 	return &client{OptOut: true}
 }
 
-// WithClient creates a new context with the provided logger attached.
+// WithClient creates a new context with the provided client attached.
 func WithClient(ctx context.Context, client *client) context.Context {
 	return context.WithValue(ctx, metricsKey, client)
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/sethvargo/go-envconfig"
@@ -41,6 +42,14 @@ const (
 
 // Assert client implements MetricWriter.
 var _ MetricWriter = (*client)(nil)
+
+// noopWriterOnce returns a function that returns the noop client, which
+// is a client with OptOut = true.
+//
+// It is initialized once when called the first time.
+var noopWriterOnce = sync.OnceValue[MetricWriter](func() MetricWriter {
+	return &client{OptOut: true}
+})
 
 // contextKey is a private string type to prevent collisions in the context map.
 type contextKey string
@@ -262,9 +271,10 @@ func (c *client) WriteMetricAsync(ctx context.Context, name string, count int64)
 	}
 }
 
-// NoopWriter returns a MetricWriter which is opted-out and will not send metrics.
+// NoopWriter returns a MetricWriter which is opted-out and will not send
+// metrics.
 func NoopWriter() MetricWriter {
-	return &client{OptOut: true}
+	return noopWriterOnce()
 }
 
 // WithClient creates a new context with the provided client attached.

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -268,7 +268,7 @@ func NoopWriter() MetricWriter {
 }
 
 // WithClient creates a new context with the provided logger attached.
-func WithLogger(ctx context.Context, client *client) context.Context {
+func WithClient(ctx context.Context, client *client) context.Context {
 	return context.WithValue(ctx, metricsKey, client)
 }
 

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -392,3 +392,27 @@ func TestWriteMetricAsync(t *testing.T) {
 		})
 	}
 }
+
+func TestContext(t *testing.T) {
+	t.Parallel()
+
+	client1 := defaultClient()
+	client2 := defaultClient()
+	client2.InstallID = "somethingDifferent"
+
+	checkFromContext(context.Background(), t, NoopWriter())
+
+	ctx := WithLogger(context.Background(), client1)
+	checkFromContext(ctx, t, client1)
+
+	ctx = WithLogger(ctx, client2)
+	checkFromContext(ctx, t, client2)
+}
+
+func checkFromContext(ctx context.Context, tb testing.TB, want MetricWriter) {
+	tb.Helper()
+
+	if diff := cmp.Diff(want, FromContext(ctx)); diff != "" {
+		tb.Errorf("unexpected metrics client in context diff (-got +want): %s", diff)
+	}
+}

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -402,10 +402,10 @@ func TestContext(t *testing.T) {
 
 	checkFromContext(context.Background(), t, NoopWriter())
 
-	ctx := WithLogger(context.Background(), client1)
+	ctx := WithClient(context.Background(), client1)
 	checkFromContext(ctx, t, client1)
 
-	ctx = WithLogger(ctx, client2)
+	ctx = WithClient(ctx, client2)
 	checkFromContext(ctx, t, client2)
 }
 

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -36,14 +36,14 @@ const (
 	testServerURL = "https://example.com"
 )
 
-func defaultClient() *client {
-	return &client{
-		AppID:      testAppID,
-		AppVersion: testVersion,
-		InstallID:  testInstallID,
-		HTTPClient: &http.Client{Timeout: 1 * time.Second},
-		OptOut:     false,
-		Config: &metricsConfig{
+func defaultClient() *Client {
+	return &Client{
+		appID:      testAppID,
+		appVersion: testVersion,
+		installID:  testInstallID,
+		httpClient: &http.Client{Timeout: 1 * time.Second},
+		optOut:     false,
+		config: &metricsConfig{
 			ServerURL: testServerURL,
 			NoMetrics: false,
 		},
@@ -59,7 +59,7 @@ func TestNew(t *testing.T) {
 			name      string
 			client    *http.Client
 			installID string
-			want      *client
+			want      *Client
 		}{
 			{
 				name: "happy_path_no_install_id",
@@ -74,9 +74,9 @@ func TestNew(t *testing.T) {
 				name:      "happy_path_with_custom_http_client",
 				installID: testInstallID,
 				client:    &http.Client{Timeout: 2},
-				want: func() *client {
+				want: func() *Client {
 					c := defaultClient()
-					c.HTTPClient = &http.Client{Timeout: 2}
+					c.httpClient = &http.Client{Timeout: 2}
 					return c
 				}(),
 			},
@@ -106,13 +106,9 @@ func TestNew(t *testing.T) {
 					opts = append(opts, WithHTTPClient(tc.client))
 				}
 
-				i, err := New(ctx, testAppID, testVersion, opts...)
+				got, err := New(ctx, testAppID, testVersion, opts...)
 				if err != nil {
 					t.Errorf("unexpected error: %s", err.Error())
-				}
-				got, ok := i.(*client)
-				if !ok {
-					t.Fatal("Expected New to return client, but cast failed.")
 				}
 
 				storedID, err := loadInstallID(testAppID, installPath)
@@ -127,15 +123,15 @@ func TestNew(t *testing.T) {
 					t.Errorf("install id not saved")
 				} else {
 					// We cannot know ahead of time if generated, so copy from got to want.
-					tc.want.InstallID = got.InstallID
+					tc.want.installID = got.installID
 				}
 
-				if diff := cmp.Diff(got.InstallID, storedID.InstallID); diff != "" {
-					t.Errorf("install id in client does not match stored. Diff (-client +stored): %s", diff)
+				if diff := cmp.Diff(got.installID, storedID.InstallID); diff != "" {
+					t.Errorf("install id in Client does not match stored. Diff (-Client +stored): %s", diff)
 				}
 
-				if diff := cmp.Diff(got, tc.want); diff != "" {
-					t.Errorf("unexpected client fields. Diff (-got +want): %s", diff)
+				if diff := cmp.Diff(got, tc.want, cmp.AllowUnexported(Client{})); diff != "" {
+					t.Errorf("unexpected Client fields. Diff (-got +want): %s", diff)
 				}
 			})
 		}
@@ -150,7 +146,7 @@ func TestNew(t *testing.T) {
 			name      string
 			appID     string
 			env       map[string]string
-			want      *client
+			want      *Client
 			wantError string
 		}{
 			{
@@ -162,7 +158,7 @@ func TestNew(t *testing.T) {
 				name:      "opt_out_env_noop_no_err",
 				appID:     testAppID,
 				env:       map[string]string{"NO_METRICS": "TRUE"},
-				want:      NoopWriter().(*client),
+				want:      NoopWriter(),
 				wantError: "",
 			},
 			{
@@ -178,21 +174,12 @@ func TestNew(t *testing.T) {
 				t.Parallel()
 
 				ctx := context.Background()
-				c, err := New(ctx, tc.appID, "1", WithLookuper(envconfig.MapLookuper(tc.env)))
-				if c == nil && tc.want != nil {
-					t.Errorf("got nil MetricWriter but expected non-nil")
-				}
-				if c != nil {
-					gotV, ok := c.(*client)
-					if !ok {
-						t.Fatal("Expected New to return client, but cast failed.")
-					}
-					if diff := cmp.Diff(gotV, tc.want); diff != "" {
-						t.Errorf("unexpected metricWriter value. Diff (-got +want): %s", diff)
-					}
-				}
+				got, err := New(ctx, tc.appID, "1", WithLookuper(envconfig.MapLookuper(tc.env)))
 				if diff := testutil.DiffErrString(err, tc.wantError); diff != "" {
 					t.Errorf("unexpected error: %s", diff)
+				}
+				if diff := cmp.Diff(got, tc.want, cmp.AllowUnexported(Client{})); diff != "" {
+					t.Errorf("unexpected Client value. Diff (-got +want): %s", diff)
 				}
 			})
 		}
@@ -204,7 +191,7 @@ func TestWriteMetric(t *testing.T) {
 
 	cases := []struct {
 		name        string
-		client      *client
+		client      *Client
 		responder   http.HandlerFunc
 		wantRequest *SendMetricRequest
 		wantErr     string
@@ -221,9 +208,9 @@ func TestWriteMetric(t *testing.T) {
 		},
 		{
 			name: "metric_opt_out_noop",
-			client: func() *client {
+			client: func() *Client {
 				c := defaultClient()
-				c.OptOut = true
+				c.optOut = true
 				return c
 			}(),
 			wantRequest: nil,
@@ -287,7 +274,7 @@ func TestWriteMetric(t *testing.T) {
 			}())
 			t.Cleanup(ts.Close)
 
-			tc.client.Config.ServerURL = ts.URL
+			tc.client.config.ServerURL = ts.URL
 
 			err := tc.client.WriteMetric(ctx, "foo", 1)
 			if diff := testutil.DiffErrString(err, tc.wantErr); diff != "" {
@@ -306,7 +293,7 @@ func TestWriteMetricAsync(t *testing.T) {
 
 	cases := []struct {
 		name        string
-		client      *client
+		client      *Client
 		timeout     time.Duration
 		wantRequest *SendMetricRequest
 		wantErr     string
@@ -334,9 +321,9 @@ func TestWriteMetricAsync(t *testing.T) {
 		},
 		{
 			name: "metric_opt_out_noop",
-			client: func() *client {
+			client: func() *Client {
 				c := defaultClient()
-				c.OptOut = true
+				c.optOut = true
 				return c
 			}(),
 			wantRequest: nil,
@@ -372,7 +359,7 @@ func TestWriteMetricAsync(t *testing.T) {
 			}())
 			t.Cleanup(ts.Close)
 
-			tc.client.Config.ServerURL = ts.URL
+			tc.client.config.ServerURL = ts.URL
 
 			ctx := context.Background()
 			if tc.timeout > 0 {
@@ -398,7 +385,7 @@ func TestContext(t *testing.T) {
 
 	client1 := defaultClient()
 	client2 := defaultClient()
-	client2.InstallID = "somethingDifferent"
+	client2.installID = "somethingDifferent"
 
 	checkFromContext(context.Background(), t, NoopWriter())
 
@@ -409,10 +396,10 @@ func TestContext(t *testing.T) {
 	checkFromContext(ctx, t, client2)
 }
 
-func checkFromContext(ctx context.Context, tb testing.TB, want MetricWriter) {
+func checkFromContext(ctx context.Context, tb testing.TB, want *Client) {
 	tb.Helper()
 
-	if diff := cmp.Diff(want, FromContext(ctx)); diff != "" {
-		tb.Errorf("unexpected metrics client in context diff (-got +want): %s", diff)
+	if diff := cmp.Diff(want, FromContext(ctx), cmp.AllowUnexported(Client{})); diff != "" {
+		tb.Errorf("unexpected metrics Client in context diff (-got +want): %s", diff)
 	}
 }

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -142,7 +142,7 @@ func TestNew(t *testing.T) {
 	t.Run("unhappy_path", func(t *testing.T) {
 		t.Parallel()
 
-		cases := []struct { //nolint:forcetypeassert
+		cases := []struct {
 			name      string
 			appID     string
 			env       map[string]string


### PR DESCRIPTION
Stealing pattern form our logging library

I'm still trying to figure out how to do the callback to ensure goroutines are waited on.

For updater it made sense to just do everything in `realMain`. But if we want to write metrics somewhere within the program (for example maybe we want to write a metric once we've parsed the command being run).

Ideas:
1. Have the client own a list of callbacks. `WriteMetricAsync()` doesn't return anything, but there will be a `Close() []error` which will wait on the goroutines. `WriteMetricAsync()` would append its closer function to some internal field in the client.

```go
// MetricWriter is a client for reporting metrics about an application's usage.
type MetricWriter interface {
	WriteMetric(ctx context.Context, name string, count int64) error
	WriteMetricAsync(ctx context.Context, name string, count int64)
	Close() []error // only return non-nil errors, maybe this belongs in the struct but not interface?
}
```

Maybe `Close() error ` with a multierr would be better, as it would be more in line with other libraries implementing `io.Closer`.

2. [My least favorite now that I write it out] Store the functions in the context using a helper function, much like we do the client. Defer a function that handles the stored functions in main.
```go
func CleanupFromContext(ctx context.Context) []func() error

// In main
client := metrics.New()
defer func(){
  funcs := CleanupFromContext(ctx)
  // iterate through funcs, handling errors
}
```

3. Just leave as is, every call stack will not return until the metric is written or timed out. This works well if we only record metrics early in the call stack, but poorly if its an early branch in the execution tree.