### PR TITLE
Avoid using assertions in log tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/google/renameio v1.0.1
 	github.com/hashicorp/go-version v1.6.0
 	github.com/sethvargo/go-envconfig v1.0.0
-	github.com/thejerf/slogassert v0.3.2
+	github.com/thejerf/slogassert v0.3.3
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -12,8 +12,8 @@ github.com/hashicorp/go-version v1.6.0 h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mO
 github.com/hashicorp/go-version v1.6.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/sethvargo/go-envconfig v1.0.0 h1:1C66wzy4QrROf5ew4KdVw942CQDa55qmlYmw9FZxZdU=
 github.com/sethvargo/go-envconfig v1.0.0/go.mod h1:Lzc75ghUn5ucmcRGIdGQ33DKJrcjk4kihFYgSTBmjIc=
-github.com/thejerf/slogassert v0.3.2 h1:sE5f1vdrPr4EFkMW75s9stRePRn4zYpRGpeUbkCR+rc=
-github.com/thejerf/slogassert v0.3.2/go.mod h1:0zn9ISLVKo1aPMTqcGfG1o6dWwt+Rk574GlUxHD4rs8=
+github.com/thejerf/slogassert v0.3.3 h1:17aIXVtHLnLodRHGuGX9E8H6KRjEPRrZX18QAD0Vp/g=
+github.com/thejerf/slogassert v0.3.3/go.mod h1:0zn9ISLVKo1aPMTqcGfG1o6dWwt+Rk574GlUxHD4rs8=
 golang.org/x/net v0.23.0 h1:7EYJ93RZ9vYSZAIb2x3lnuvqO5zneoD6IvWjuhfxjTs=
 golang.org/x/net v0.23.0/go.mod h1:JKghWKKOSdJwpW2GEx0Ja7fmaKnMsbu+MWVZTokSYmg=
 golang.org/x/sys v0.18.0 h1:DBdB3niSjOA/O0blCZBqDefyWNYveAYMNF1Wum0DYQ4=

--- a/pkg/server/metrichandler_test.go
+++ b/pkg/server/metrichandler_test.go
@@ -255,11 +255,10 @@ func TestHandleMetric(t *testing.T) {
 			// Normally we wouldn't test log messages, but as that is the way metrics
 			// are being exported, it seems important to do so here.
 			for k, want := range tc.wantLogs {
-				// TODO: Switch to logHandler.Assert() if https://github.com/thejerf/slogassert/pull/5 is merged.
-				// This violates https://google.github.io/styleguide/go/decisions#assertion-libraries
-				// in it's current state, if pr is merged I will be able to avoid that
-				// path.
-				if got := logHandler.AssertSomePrecise(*k); got != want {
+				got := logHandler.Assert(func(lm slogassert.LogMessage) bool {
+					return k.Matches(lm)
+				})
+				if got != want {
 					t.Errorf("Unexpected number of logs containing [%v]. Got [%d], want [%d]", k, got, want)
 				}
 			}


### PR DESCRIPTION
My changes to the slogassert library were approved, so now I can be compliant with style guide.